### PR TITLE
Add slave scenes as list and return corrected length tuple if stitch fails at `stitch_pair`

### DIFF
--- a/interferogram/ifg_stitcher.py
+++ b/interferogram/ifg_stitcher.py
@@ -545,7 +545,8 @@ class IfgStitcher:
        
         over,overlap_mask = self.get_ovelap([im,im1],[wmsk1,wmsk2],length,width,[i1,i2],[j1,j2],False)
         if len(over[0]) == 0:
-            return None,None,None
+            return None,None,None,None
+
         #don't touch the zeros so use this mask
         nmask1 = np.nonzero(np.abs(im) < self._small)
         nmask2 = np.abs(im1) < self._small

--- a/interferogram/stitch_ifgs.py
+++ b/interferogram/stitch_ifgs.py
@@ -156,7 +156,7 @@ def create_met_json(id, version, env, starttime, endtime, met_files, met_json_fi
                   'sensor', 'lookDirection', 'platform', 'startingRange',
                   'beamMode', 'direction', 'prf' )
     single_params = ('temporal_span', 'trackNumber')
-    list_params = ('platform', 'swath', 'perpendicularBaseline', 'parallelBaseline')
+    list_params = ('master_scenes', 'slave_scenes', 'platform', 'swath', 'perpendicularBaseline', 'parallelBaseline')
     mean_params = ('perpendicularBaseline', 'parallelBaseline')
     for i, met_file in enumerate(met_files):
         with open(met_file) as f:


### PR DESCRIPTION
This is applied in eos' ariamh through this PR:
https://github.com/earthobservatory/ariamh/pull/3